### PR TITLE
lexer: replace 'if ... or ... or' with 'if a in b'

### DIFF
--- a/pythonect/internal/lexer.py
+++ b/pythonect/internal/lexer.py
@@ -65,15 +65,11 @@ def t_SOURCE(t):
 
             # `[]` , `()` and '{}'
 
-            if char == '[' \
-            or char == '(' \
-            or char == '{':
+            if char in '[({':
 
                 scope = scope + 1
 
-            if char == ']' \
-            or char == ')' \
-            or char == '}':
+            if char in '])}':
 
                 scope = scope - 1
 


### PR DESCRIPTION
I think this is easier to read and debug -- and the strings (`"[({"` and `"])}"`) could be factored out as module-level constants.
