### PR TITLE
docs: fix simple typo, evaulated -> evaluated

### DIFF
--- a/doc/tutorial/controlflow.rst
+++ b/doc/tutorial/controlflow.rst
@@ -57,7 +57,7 @@ Using Multithreading as ``elif`` and ``else``
 ---------------------------------------------
 
 Since there's no ``if``, there's also no ``elif`` or ``else``, instead all
-possible flows are evaulated at once. For example: 
+possible flows are evaluated at once. For example: 
 ::
 
     "Hello, world" -> [[_.startswith('Hello') -> print "1"], [[_ != 'foobar'] -> print "2" ]]


### PR DESCRIPTION
There is a small typo in doc/tutorial/controlflow.rst.

Should read `evaluated` rather than `evaulated`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md